### PR TITLE
fix: sitemap configuration

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,9 +27,6 @@ export default {
     // https://pwa.nuxtjs.org/
     '@nuxtjs/pwa',
 
-    // https://github.com/nuxt-community/sitemap-module
-    '@nuxtjs/sitemap',
-
     // https://github.com/nuxt-community/robots-module
     '@nuxtjs/robots',
 
@@ -60,7 +57,10 @@ export default {
           }
         ]
       }
-    ]
+    ],
+    
+    // https://github.com/nuxt-community/sitemap-module
+    '@nuxtjs/sitemap'
 
     // https://github.com/nuxt-community/sentry-module
     // "@nuxtjs/sentry",
@@ -79,6 +79,10 @@ export default {
     // Simple usage
     '@nuxtjs/vuetify'
   ],
+  
+  sitemap: {
+    hostname: 'https://satupadu.org'
+  },
 
   vuetify: {
     theme: {


### PR DESCRIPTION
Hi @jefrydco,

First off all, thank you to use my nuxt sitemap module 😉 
I just found few mistakes in your `nuxt.config.js` about the following [sitemap.xml](https://satupadu.org/sitemap.xml)

The sitemap module must be declared after the nuxt-i18n module in order to support the i18n routes.
see "notice" in the "usage" section of the sitemap-module docs: https://github.com/nuxt-community/sitemap-module#usage

Then, the hostname is missing from the configuration. The option is mandatory if you build nuxt in "spa" or "generate" mode.
see https://github.com/nuxt-community/sitemap-module#hostname-optional---string

Your `/sitemapxml` before:
```xml
<url>
  <loc>http://jefrydco/</loc>
</url>
```

and after the patch:
```xml
<url>
  <loc>https://satupadu.org/</loc>
</url>
<url>
  <loc>https://satupadu.org/en/</loc>
</url>
```